### PR TITLE
option to trim psf

### DIFF
--- a/bin/mdet-lsst-sim
+++ b/bin/mdet-lsst-sim
@@ -16,6 +16,10 @@ def get_args():
 
     parser.add_argument('--mdet-config', help='optional config file')
 
+    parser.add_argument('--trim-psf', action='store_true',
+                        help=("trim the psf to avoid bad pixels in coadd psf "
+                              "rather than relying on zeroing"))
+
     parser.add_argument('--use-sx', action='store_true',
                         help=('use sx based metadetect'))
     parser.add_argument('--deblend', action='store_true',
@@ -70,6 +74,7 @@ def main():
         show_sheared=args.show_sheared,
         show_masks=args.show_masks,
         show_sim=args.show_sim,
+        trim_psf=args.trim_psf,
         use_sx=args.use_sx,
         deblend=args.deblend,
         nostack=args.nostack,

--- a/mdet_lsst_sim/run.py
+++ b/mdet_lsst_sim/run.py
@@ -28,6 +28,7 @@ def run(
     show_masks=False,
     show_sim=False,
     nostack=False,
+    trim_psf=False,
     use_sx=False,
     deblend=False,
     interp_bright=False,
@@ -60,6 +61,9 @@ def run(
         If True, show the sims.  default False
     nostack: bool
         If True, don't use any lsst stack code, default False
+    trim_psf: bool
+        If True, trim the psf to psf_dim/np.sqrt(3) to avoid bad pixels
+        in coadded psf
     use_sx: bool
         If True, us sx for detection, default False
     deblend: bool
@@ -147,6 +151,13 @@ def run(
             else:
 
                 psf_dim = sim.psf_dim
+                if trim_psf:
+                    psf_dim = int(psf_dim/np.sqrt(3))
+                    if psf_dim % 2 == 0:
+                        psf_dim -= 1
+                    logger.info(
+                        "trimming psf %d -> %d" % (sim.psf_dim, psf_dim)
+                    )
 
                 mbc = MultiBandCoadds(
                     rng=trial_rng,


### PR DESCRIPTION
This avoids bad pixels which would have to be set to zero or
interpolated

I'm putting this option back in to see if it has any impact on shear recovery at low s/n